### PR TITLE
Added headerOffset API to change headerOffset dynamically

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -146,6 +146,16 @@ $.extend( FixedHeader.prototype, {
 	},
 	
 	/**
+	 * Set headerOffset 
+	 *
+	 * @param  {int} new value for headerOffset
+	 */
+	headerOffset: function ( topOffset )
+  {
+		this.c.headerOffset = topOffset;
+  },
+	
+	/**
 	 * Recalculate the position of the fixed elements and force them into place
 	 */
 	update: function ()
@@ -561,6 +571,15 @@ DataTable.Api.register( 'fixedHeader.disable()', function ( ) {
 	} );
 } );
 
+DataTable.Api.register( 'fixedHeader.headerOffset()', function ( topOffset ) {
+	return this.iterator( 'table', function ( ctx ) {
+		var fh = ctx._fixedHeader;
+
+		if ( fh ) {
+			fh.headerOffset( topOffset );
+		}
+	} );
+} );
 
 return FixedHeader;
 }));


### PR DESCRIPTION
For the cases when headerOffset of an existing fixedHeader need to be
changed, introduced headerOffset() API.
Usage:  table.fixedHeader.headerOffset( topOffset );
